### PR TITLE
Fix build and update library to 3.1.1

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -78,31 +78,12 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     }) orelse return;
-    const system_sdk_dep = b.lazyDependency("system_sdk", .{}) orelse return;
 
     const samples_mod = b.createModule(.{
         .target = target,
         .optimize = optimize,
         .link_libcpp = true,
     });
-
-    switch (target.result.os.tag) {
-        .macos => {
-            samples_mod.addLibraryPath(system_sdk_dep.path("macos12/usr/lib"));
-            samples_mod.addSystemIncludePath(system_sdk_dep.path("macos12/usr/include"));
-            samples_mod.addFrameworkPath(system_sdk_dep.path("macos12/System/Library/Frameworks"));
-        },
-        .linux => {
-            if (target.result.cpu.arch.isX86()) {
-                samples_mod.addLibraryPath(system_sdk_dep.path("linux/lib/x86_64-linux-gnu"));
-            } else {
-                samples_mod.addLibraryPath(system_sdk_dep.path("linux/lib/aarch64-linux-gnu"));
-            }
-
-            samples_mod.addSystemIncludePath(system_sdk_dep.path("linux/include"));
-        },
-        else => {},
-    }
 
     samples_mod.linkLibrary(box2d_lib);
     samples_mod.addIncludePath(box2d_dep.path("shared"));

--- a/build.zig
+++ b/build.zig
@@ -62,9 +62,18 @@ pub fn build(b: *std.Build) void {
     const testing = b.option(bool, "test", "Enable test applications (examples, benchmarks)") orelse false;
     if (!testing) return;
 
-    const glfw_dep = b.lazyDependency("glfw", .{}) orelse return;
-    const imgui_dep = b.lazyDependency("imgui", .{}) orelse return;
-    const enki_dep = b.lazyDependency("enkits", .{}) orelse return;
+    const glfw_dep = b.lazyDependency("glfw", .{
+        .target = target,
+        .optimize = optimize,
+    }) orelse return;
+    const imgui_dep = b.lazyDependency("imgui", .{
+        .target = target,
+        .optimize = optimize,
+    }) orelse return;
+    const enki_dep = b.lazyDependency("enkits", .{
+        .target = target,
+        .optimize = optimize,
+    }) orelse return;
 
     const samples_exe = b.addExecutable(.{
         .name = "samples",

--- a/build.zig
+++ b/build.zig
@@ -17,10 +17,11 @@ pub fn build(b: *std.Build) void {
     lib.addCSourceFiles(.{
         .root = box2d_dep.path("src"),
         .flags = &.{
-            "-std=c17",
+            "-std=gnu17",
         },
         .files = &.{
             "aabb.c",
+            "arena_allocator.c",
             "array.c",
             "bitset.c",
             "body.c",
@@ -41,12 +42,13 @@ pub fn build(b: *std.Build) void {
             "math_functions.c",
             "motor_joint.c",
             "mouse_joint.c",
+            "mover.c",
             "prismatic_joint.c",
             "revolute_joint.c",
+            "sensor.c",
             "shape.c",
             "solver.c",
             "solver_set.c",
-            "stack_allocator.c",
             "table.c",
             "timer.c",
             "types.c",
@@ -75,7 +77,10 @@ pub fn build(b: *std.Build) void {
     samples_exe.addIncludePath(box2d_dep.path("extern/glad/include"));
     samples_exe.addIncludePath(box2d_dep.path("extern/jsmn"));
     samples_exe.addCSourceFiles(.{
-        .flags = &.{},
+        .flags = &.{
+            "-DIMGUI_DISABLE_OBSOLETE_FUNCTIONS",
+            "-std=c++20",
+        },
         .root = box2d_dep.path("samples"),
         .files = &.{
             "car.cpp",
@@ -86,6 +91,7 @@ pub fn build(b: *std.Build) void {
             "sample.cpp",
             "sample_benchmark.cpp",
             "sample_bodies.cpp",
+            "sample_character.cpp",
             "sample_collision.cpp",
             "sample_continuous.cpp",
             "sample_determinism.cpp",
@@ -96,16 +102,18 @@ pub fn build(b: *std.Build) void {
             "sample_shapes.cpp",
             "sample_stacking.cpp",
             "sample_world.cpp",
-            "settings.cpp",
             "shader.cpp",
         },
     });
     samples_exe.addCSourceFiles(.{
-        .flags = &.{},
+        .flags = &.{
+            "-std=gnu17",
+        },
         .root = box2d_dep.path("."),
         .files = &.{
             "extern/glad/src/glad.c",
             "shared/benchmarks.c",
+            "shared/determinism.c",
             "shared/human.c",
             "shared/random.c",
         },
@@ -115,7 +123,8 @@ pub fn build(b: *std.Build) void {
     samples_exe.addIncludePath(imgui_dep.path("backends"));
     samples_exe.addCSourceFiles(.{
         .flags = &.{
-            "-std=c++17",
+            "-DIMGUI_DISABLE_OBSOLETE_FUNCTIONS",
+            "-std=c++20",
         },
         .root = imgui_dep.path("."),
         .files = &.{
@@ -132,7 +141,9 @@ pub fn build(b: *std.Build) void {
     samples_exe.linkLibrary(glfw_dep.artifact("glfw"));
     samples_exe.addIncludePath(enki_dep.path("src"));
     samples_exe.addCSourceFiles(.{
-        .flags = &.{},
+        .flags = &.{
+            "-std=c++11",
+        },
         .root = enki_dep.path("src"),
         .files = &.{
             "TaskScheduler.cpp",

--- a/build.zig
+++ b/build.zig
@@ -85,6 +85,10 @@ pub fn build(b: *std.Build) void {
         .link_libcpp = true,
     });
 
+    if (target.result.os.tag == .macos) {
+        samples_mod.linkFramework("QuartzCore", .{});
+    }
+
     samples_mod.linkLibrary(box2d_lib);
     samples_mod.addIncludePath(box2d_dep.path("shared"));
     samples_mod.addIncludePath(box2d_dep.path("extern/glad/include"));

--- a/build.zig
+++ b/build.zig
@@ -86,8 +86,22 @@ pub fn build(b: *std.Build) void {
         .link_libcpp = true,
     });
 
-    if (target.result.os.tag == .linux) {
-        samples_mod.addIncludePath(system_sdk_dep.path("linux/include"));
+    switch (target.result.os.tag) {
+        .macos => {
+            samples_mod.addLibraryPath(system_sdk_dep.path("macos12/usr/lib"));
+            samples_mod.addSystemIncludePath(system_sdk_dep.path("macos12/usr/include"));
+            samples_mod.addFrameworkPath(system_sdk_dep.path("macos12/System/Library/Frameworks"));
+        },
+        .linux => {
+            if (target.result.cpu.arch.isX86()) {
+                samples_mod.addLibraryPath(system_sdk_dep.path("linux/lib/x86_64-linux-gnu"));
+            } else {
+                samples_mod.addLibraryPath(system_sdk_dep.path("linux/lib/aarch64-linux-gnu"));
+            }
+
+            samples_mod.addSystemIncludePath(system_sdk_dep.path("linux/include"));
+        },
+        else => {},
     }
 
     samples_mod.linkLibrary(box2d_lib);

--- a/build.zig
+++ b/build.zig
@@ -74,12 +74,18 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     }) orelse return;
+    const system_sdk_dep = b.lazyDependency("system_sdk", .{}) orelse return;
 
     const samples_exe = b.addExecutable(.{
         .name = "samples",
         .target = target,
         .optimize = optimize,
     });
+
+    if (target.result.os.tag == .linux) {
+        samples_exe.addIncludePath(system_sdk_dep.path("linux/include"));
+    }
+
     samples_exe.linkLibrary(lib);
     samples_exe.linkLibCpp();
     samples_exe.addIncludePath(box2d_dep.path("shared"));

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -24,6 +24,10 @@
             .hash = "1220f4b8ca688dfad1e7e33603398bceec6cae189257e1bbc86c4b87177a33022e95",
             .lazy = true,
         },
+        .system_sdk = .{
+            .url = "git+https://github.com/zig-gamedev/system_sdk#c0dbf11cdc17da5904ea8a17eadc54dee26567ec",
+            .hash = "system_sdk-0.3.0-dev-alwUNnYaaAJAtIdE2fg4NQfDqEKs7QCXy_qYukAOBfmF",
+        },
     },
     .paths = .{
         "build.zig",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -27,6 +27,7 @@
         .system_sdk = .{
             .url = "git+https://github.com/zig-gamedev/system_sdk#c0dbf11cdc17da5904ea8a17eadc54dee26567ec",
             .hash = "system_sdk-0.3.0-dev-alwUNnYaaAJAtIdE2fg4NQfDqEKs7QCXy_qYukAOBfmF",
+            .lazy = true,
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -24,11 +24,6 @@
             .hash = "1220f4b8ca688dfad1e7e33603398bceec6cae189257e1bbc86c4b87177a33022e95",
             .lazy = true,
         },
-        .system_sdk = .{
-            .url = "git+https://github.com/zig-gamedev/system_sdk#c0dbf11cdc17da5904ea8a17eadc54dee26567ec",
-            .hash = "system_sdk-0.3.0-dev-alwUNnYaaAJAtIdE2fg4NQfDqEKs7QCXy_qYukAOBfmF",
-            .lazy = true,
-        },
     },
     .paths = .{
         "build.zig",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,25 +1,27 @@
 .{
-    .name = "box2d",
-    .version = "3.0.0-1",
+    .name = .box2d,
+    .version = "3.1.1",
+    .fingerprint = 0xbbd8fcbd9341b172,
+    .minimum_zig_version = "0.14.1",
     .dependencies = .{
         .box2d = .{
-            .url = "git+https://github.com/erincatto/box2d.git?ref=main#f377034920c42a26cd498c0a0b1b2e9f2b064989",
-            .hash = "1220c6750412ebc698694cd08aca4fe87fda8e2df0d4ffa7d33e7de5b8ca5bebb643",
+            .url = "git+https://github.com/erincatto/box2d#8c661469c9507d3ad6fbd2fea3f1aa71669c2fe3",
+            .hash = "1220b4804d83fcfcad9e76c9e4ec3fb58f87db9dcd96584393f9f57874c491bafa63",
         },
         // Below dependencies are only used by sample application
         .glfw = .{
-            .url = "git+https://github.com/emidoots/glfw?ref=master#ec656e10d3643a3a71149bb96ae6b0831b84b677",
-            .hash = "12207be469bad84baed2ede75cf89ede37e1ed5ee8be62a54d2b2112c5f56a44cc89",
+            .url = "git+https://github.com/allyourcodebase/glfw#98607df9bce062c7fd837d58fafa06dae22edb04",
+            .hash = "12203f465aebf4747dd5e8e419df8afc9c828e45f3fd4ddbfa3a7d08f075af834109",
             .lazy = true,
         },
         .imgui = .{
-            .url = "git+https://github.com/ocornut/imgui?ref=v1.91.3#cb16568fca5297512ff6a8f3b877f461c4323fbe",
+            .url = "git+https://github.com/ocornut/imgui#cb16568fca5297512ff6a8f3b877f461c4323fbe",
             .hash = "1220dbde2c4211686e4d0431c0969fe48af2bd7f859d3eab9ee22b3c64750d86c408",
             .lazy = true,
         },
         .enkits = .{
-            .url = "git+https://github.com/dougbinks/enkiTS?ref=master#686d0ec31829e0d9e5edf9ceb68c40f9b9b20ea9",
-            .hash = "1220c5ff6b113f3ccfae2412919b8ea92103885fae82acd9d63250f192ae2f5651e1",
+            .url = "git+https://github.com/dougbinks/enkiTS#771a0876f7b1b26a9c9381f476b31b08798583cf",
+            .hash = "1220f4b8ca688dfad1e7e33603398bceec6cae189257e1bbc86c4b87177a33022e95",
             .lazy = true,
         },
     },


### PR DESCRIPTION
This PR:

- fixes #1
  - define `IMGUI_DISABLE_OBSOLETE_FUNCTIONS`
- fixes #2
  - use `-std=gnu17` instead of `-std=c17`
- fixes #3
  - update `build.zig.zon` fields and set minimum zig version to `0.14.1`
- updates Box2D to version 3.1.1
  - also updates and/or canonicalizes dependencies (replace dead glfw repository)
  - specify C/C++ language standard flags for all source files (taken from Box2D CMake files)

Library/Samples:

- [x] zig build -Dtarget=aarch64-linux-gnu
- [x] zig build -Dtarget=aarch64-linux-musl
- [x] zig build -Dtarget=aarch64-macos
- [x] zig build -Dtarget=x86_64-linux-gnu
- [x] zig build -Dtarget=x86_64-linux-musl
- [x] zig build -Dtarget=x86_64-windows
- [x] zig build -Dtest -Dtarget=aarch64-linux-gnu
- [x] zig build -Dtest -Dtarget=aarch64-linux-musl
- [ ] zig build -Dtest -Dtarget=aarch64-macos
    - Compiler error: `unable to find dynamic system library 'objc' using strategy 'paths_first'. searched paths: none`
- [x] zig build -Dtest -Dtarget=x86_64-linux-gnu
- [x] zig build -Dtest -Dtarget=x86_64-linux-musl
- [x] zig build -Dtest -Dtarget=x86_64-windows

Tested:

- [x] zig build run -Dtest -Dtarget=x86_64-linux-gnu
- [ ] zig build run -Dtest -Dtarget=x86_64-linux-musl
    - Runtime error: `GLFW error occurred. Code: 65544. Description: X11: Failed to load Xlib`